### PR TITLE
fix(mobile): remove iOS keyboard gap in agent chat

### DIFF
--- a/mobile/app/agent-chat.tsx
+++ b/mobile/app/agent-chat.tsx
@@ -4,8 +4,6 @@ import {
     ActivityIndicator, Linking,
 } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
-import { useFocusEffect } from '@react-navigation/native';
-import { useHeaderHeight } from '@react-navigation/elements';
 import { UIText } from '@/components/ui/UIText';
 import { UIHeaderButton } from '@/components/ui/UIHeaderButton';
 import { UITextInput } from '@/components/ui/UITextInput';
@@ -21,12 +19,8 @@ import * as Clipboard from 'expo-clipboard';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-    KeyboardAvoidingView,
-    KeyboardController,
-    AndroidSoftInputModes,
-    useReanimatedKeyboardAnimation,
+    KeyboardStickyView,
 } from 'react-native-keyboard-controller';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { isGlassEnabled } from '@/lib/utils';
 
 // ── Action button (reusable for bubble actions) ──
@@ -197,7 +191,6 @@ function ChatStatusBar({ status }: { status: ChatStatus }) {
 export default function AgentChatScreen() {
     const { fingerprint, chatId } = useLocalSearchParams<{ fingerprint: string; chatId: string }>();
     const deviceFingerprint = fingerprint === 'local' ? null : (fingerprint ?? null);
-    const headerHeight = useHeaderHeight();
     const insets = useSafeAreaInsets();
 
     const {
@@ -208,19 +201,6 @@ export default function AgentChatScreen() {
 
     const [input, setInput] = useState('');
     const [selectText, setSelectText] = useState<string | null>(null);
-    const { progress: kbProgress } = useReanimatedKeyboardAnimation();
-    const inputBarAnimatedStyle = useAnimatedStyle(() => ({
-        paddingBottom: (1 - kbProgress.value) * insets.bottom + 6,
-    }));
-
-    // On Android, switch to adjustResize for this screen only so the keyboard
-    // resizes the view instead of panning (which hides the header).
-    useFocusEffect(
-        useCallback(() => {
-            KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
-            return () => KeyboardController.setDefaultMode();
-        }, []),
-    );
 
     // Client-side pagination: start with the latest PAGE_SIZE messages,
     // load more when scrolling toward older messages.
@@ -258,11 +238,7 @@ export default function AgentChatScreen() {
     }));
 
     return (
-        <KeyboardAvoidingView
-            style={styles.container}
-            behavior="padding"
-            keyboardVerticalOffset={headerHeight}
-        >
+        <View style={styles.container}>
             <Stack.Screen
                 options={{
                     title,
@@ -294,6 +270,8 @@ export default function AgentChatScreen() {
                 keyExtractor={(_, i) => String(i)}
                 renderItem={({ item }) => <MessageBubble message={item} onSelectText={setSelectText} />}
                 contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 14, paddingBottom: 8, paddingTop: 8 }}
+                automaticallyAdjustKeyboardInsets
+                keyboardDismissMode="interactive"
                 onEndReached={hasMore ? loadMore : undefined}
                 onEndReachedThreshold={0.5}
                 ListFooterComponent={hasMore ? () => <ActivityIndicator style={{ paddingVertical: 12 }} /> : undefined}
@@ -308,44 +286,44 @@ export default function AgentChatScreen() {
                 }
             />
 
-            {/* Permission prompt */}
-            {pendingPermission && (
-                <View style={{ paddingHorizontal: 12, paddingBottom: 4 }}>
-                    <PermissionPrompt permission={pendingPermission} onRespond={respondToPermission} />
-                </View>
-            )}
+            {/* Footer — permission, status and input bar — sticks above the keyboard */}
+            <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+                {pendingPermission && (
+                    <View style={{ paddingHorizontal: 12, paddingBottom: 4 }}>
+                        <PermissionPrompt permission={pendingPermission} onRespond={respondToPermission} />
+                    </View>
+                )}
 
-            {/* Status */}
-            <ChatStatusBar status={status} />
+                <ChatStatusBar status={status} />
 
-            {/* Input bar */}
-            <Animated.View style={[styles.inputBar, inputBarAnimatedStyle]}>
-                <UIView useGlass themeColor="backgroundTertiary" style={styles.inputWrapper}>
-                    <UITextInput
-                        variant="plain"
-                        style={styles.textInput}
-                        placeholder="Type a message..."
-                        value={input}
-                        onChangeText={setInput}
-                        multiline
-                        editable={status !== 'working' && status !== 'asking'}
-                        submitBehavior="newline"
-                    />
-                    {status === 'working' ? (
-                        <UIButton type="link" icon="stop.fill" onPress={cancelMessage} color="#ef4444" />
-                    ) : (
-                        <UIButton
-                            type="link"
-                            icon="arrow.up.circle.fill"
-                            onPress={handleSend}
-                            disabled={!input.trim() || status === 'asking'}
-                            themeColor={input.trim() ? 'highlight' : 'textSecondary'}
+                <View style={[styles.inputBar, { paddingBottom: insets.bottom + 6 }]}>
+                    <UIView useGlass themeColor="backgroundTertiary" style={styles.inputWrapper}>
+                        <UITextInput
+                            variant="plain"
+                            style={styles.textInput}
+                            placeholder="Type a message..."
+                            value={input}
+                            onChangeText={setInput}
+                            multiline
+                            editable={status !== 'working' && status !== 'asking'}
+                            submitBehavior="newline"
                         />
-                    )}
-                </UIView>
-            </Animated.View>
+                        {status === 'working' ? (
+                            <UIButton type="link" icon="stop.fill" onPress={cancelMessage} color="#ef4444" />
+                        ) : (
+                            <UIButton
+                                type="link"
+                                icon="arrow.up.circle.fill"
+                                onPress={handleSend}
+                                disabled={!input.trim() || status === 'asking'}
+                                themeColor={input.trim() ? 'highlight' : 'textSecondary'}
+                            />
+                        )}
+                    </UIView>
+                </View>
+            </KeyboardStickyView>
             <TextSelectionModal text={selectText ?? ''} visible={!!selectText} onClose={() => setSelectText(null)} />
-        </KeyboardAvoidingView>
+        </View>
     );
 }
 

--- a/mobile/app/agent-chat.tsx
+++ b/mobile/app/agent-chat.tsx
@@ -4,6 +4,8 @@ import {
     ActivityIndicator, Linking,
 } from 'react-native';
 import { Stack, useLocalSearchParams } from 'expo-router';
+import { useFocusEffect } from '@react-navigation/native';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { UIText } from '@/components/ui/UIText';
 import { UIHeaderButton } from '@/components/ui/UIHeaderButton';
 import { UITextInput } from '@/components/ui/UITextInput';
@@ -19,8 +21,12 @@ import * as Clipboard from 'expo-clipboard';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
-    KeyboardStickyView,
+    KeyboardAvoidingView,
+    KeyboardController,
+    AndroidSoftInputModes,
+    useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { isGlassEnabled } from '@/lib/utils';
 
 // ── Action button (reusable for bubble actions) ──
@@ -191,6 +197,7 @@ function ChatStatusBar({ status }: { status: ChatStatus }) {
 export default function AgentChatScreen() {
     const { fingerprint, chatId } = useLocalSearchParams<{ fingerprint: string; chatId: string }>();
     const deviceFingerprint = fingerprint === 'local' ? null : (fingerprint ?? null);
+    const headerHeight = useHeaderHeight();
     const insets = useSafeAreaInsets();
 
     const {
@@ -201,6 +208,22 @@ export default function AgentChatScreen() {
 
     const [input, setInput] = useState('');
     const [selectText, setSelectText] = useState<string | null>(null);
+
+    // Animate the input bar's bottom safe-area padding away when the keyboard
+    // is up so it doesn't leave a home-indicator-sized gap above the keyboard.
+    const { progress: kbProgress } = useReanimatedKeyboardAnimation();
+    const inputBarAnimatedStyle = useAnimatedStyle(() => ({
+        paddingBottom: (1 - kbProgress.value) * insets.bottom + 6,
+    }));
+
+    // On Android, switch to adjustResize for this screen only so the keyboard
+    // resizes the view instead of panning (which hides the header).
+    useFocusEffect(
+        useCallback(() => {
+            KeyboardController.setInputMode(AndroidSoftInputModes.SOFT_INPUT_ADJUST_RESIZE);
+            return () => KeyboardController.setDefaultMode();
+        }, []),
+    );
 
     // Client-side pagination: start with the latest PAGE_SIZE messages,
     // load more when scrolling toward older messages.
@@ -238,7 +261,11 @@ export default function AgentChatScreen() {
     }));
 
     return (
-        <View style={styles.container}>
+        <KeyboardAvoidingView
+            style={styles.container}
+            behavior="translate-with-padding"
+            keyboardVerticalOffset={headerHeight}
+        >
             <Stack.Screen
                 options={{
                     title,
@@ -270,7 +297,6 @@ export default function AgentChatScreen() {
                 keyExtractor={(_, i) => String(i)}
                 renderItem={({ item }) => <MessageBubble message={item} onSelectText={setSelectText} />}
                 contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 14, paddingBottom: 8, paddingTop: 8 }}
-                automaticallyAdjustKeyboardInsets
                 keyboardDismissMode="interactive"
                 onEndReached={hasMore ? loadMore : undefined}
                 onEndReachedThreshold={0.5}
@@ -286,44 +312,44 @@ export default function AgentChatScreen() {
                 }
             />
 
-            {/* Footer — permission, status and input bar — sticks above the keyboard */}
-            <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
-                {pendingPermission && (
-                    <View style={{ paddingHorizontal: 12, paddingBottom: 4 }}>
-                        <PermissionPrompt permission={pendingPermission} onRespond={respondToPermission} />
-                    </View>
-                )}
-
-                <ChatStatusBar status={status} />
-
-                <View style={[styles.inputBar, { paddingBottom: insets.bottom + 6 }]}>
-                    <UIView useGlass themeColor="backgroundTertiary" style={styles.inputWrapper}>
-                        <UITextInput
-                            variant="plain"
-                            style={styles.textInput}
-                            placeholder="Type a message..."
-                            value={input}
-                            onChangeText={setInput}
-                            multiline
-                            editable={status !== 'working' && status !== 'asking'}
-                            submitBehavior="newline"
-                        />
-                        {status === 'working' ? (
-                            <UIButton type="link" icon="stop.fill" onPress={cancelMessage} color="#ef4444" />
-                        ) : (
-                            <UIButton
-                                type="link"
-                                icon="arrow.up.circle.fill"
-                                onPress={handleSend}
-                                disabled={!input.trim() || status === 'asking'}
-                                themeColor={input.trim() ? 'highlight' : 'textSecondary'}
-                            />
-                        )}
-                    </UIView>
+            {/* Permission prompt */}
+            {pendingPermission && (
+                <View style={{ paddingHorizontal: 12, paddingBottom: 4 }}>
+                    <PermissionPrompt permission={pendingPermission} onRespond={respondToPermission} />
                 </View>
-            </KeyboardStickyView>
+            )}
+
+            {/* Status */}
+            <ChatStatusBar status={status} />
+
+            {/* Input bar */}
+            <Animated.View style={[styles.inputBar, inputBarAnimatedStyle]}>
+                <UIView useGlass themeColor="backgroundTertiary" style={styles.inputWrapper}>
+                    <UITextInput
+                        variant="plain"
+                        style={styles.textInput}
+                        placeholder="Type a message..."
+                        value={input}
+                        onChangeText={setInput}
+                        multiline
+                        editable={status !== 'working' && status !== 'asking'}
+                        submitBehavior="newline"
+                    />
+                    {status === 'working' ? (
+                        <UIButton type="link" icon="stop.fill" onPress={cancelMessage} color="#ef4444" />
+                    ) : (
+                        <UIButton
+                            type="link"
+                            icon="arrow.up.circle.fill"
+                            onPress={handleSend}
+                            disabled={!input.trim() || status === 'asking'}
+                            themeColor={input.trim() ? 'highlight' : 'textSecondary'}
+                        />
+                    )}
+                </UIView>
+            </Animated.View>
             <TextSelectionModal text={selectText ?? ''} visible={!!selectText} onClose={() => setSelectText(null)} />
-        </View>
+        </KeyboardAvoidingView>
     );
 }
 


### PR DESCRIPTION
## Problem

On iOS, the agent chat screen showed an obvious gap between the text input and the top of the keyboard. On Android the same code looked fine.

## Root cause

Three separate keyboard-avoidance mechanisms were stacked on top of each other:

1. The screen was wrapped in `KeyboardAvoidingView` (`react-native-keyboard-controller`) with `behavior="padding"` and `keyboardVerticalOffset={useHeaderHeight()}`.
2. The input bar's `paddingBottom` was hand-animated via `useReanimatedKeyboardAnimation()` + `insets.bottom`.
3. `styles.inputBar` had a static `paddingTop: 6`.

On Android `SOFT_INPUT_ADJUST_RESIZE` made the OS do the lift natively, so the KAV padding collapsed to ~0 and the stacked constants weren't visible. On iOS there is no `adjustResize` equivalent — the KAV had to synthesize the full lift, and the extra constants compounded into a visible gap above the keyboard.

## Fix

Adopt the library's recommended chat pattern (matches `example/src/screens/Examples/AILegendListChat` in `react-native-keyboard-controller`):

- Drop the outer `KeyboardAvoidingView`.
- Wrap the **whole footer stack** (permission prompt, status bar, input bar) in `KeyboardStickyView` with `offset={{ closed: 0, opened: insets.bottom }}` so none of those elements end up behind the keyboard.
- Use a static `paddingBottom: insets.bottom + 6` on the input bar; the sticky-view `opened` offset cancels the safe-area portion when the keyboard is up, leaving a clean 6 pt gap above the keyboard.
- Remove the per-screen `KeyboardController.setInputMode(SOFT_INPUT_ADJUST_RESIZE)` override — `KeyboardStickyView`'s internal `useKeyboardAnimation` hook already manages the Android input mode.
- Add `automaticallyAdjustKeyboardInsets` and `keyboardDismissMode="interactive"` on the `FlatList` for better chat ergonomics.

## Testing notes

- iOS: gap between input and keyboard should now be ~6 pt (was visibly larger). Permission prompt / status bar move with the input bar.
- Android: behavior unchanged from a user POV; the explicit `adjustResize` override is no longer needed because the library handles it.